### PR TITLE
Require phone for user and support phone login

### DIFF
--- a/src/ArabianCo.Application/Authorization/Accounts/AccountAppService.cs
+++ b/src/ArabianCo.Application/Authorization/Accounts/AccountAppService.cs
@@ -41,6 +41,7 @@ namespace ArabianCo.Authorization.Accounts
                 input.Name,
                 input.Surname,
                 input.EmailAddress,
+                input.PhoneNumber,
                 input.UserName,
                 input.Password,
                 true // Assumed email address is always confirmed. Change this if you want to implement email confirmation.

--- a/src/ArabianCo.Application/Authorization/Accounts/Dto/RegisterInput.cs
+++ b/src/ArabianCo.Application/Authorization/Accounts/Dto/RegisterInput.cs
@@ -21,10 +21,13 @@ namespace ArabianCo.Authorization.Accounts.Dto
         [StringLength(AbpUserBase.MaxUserNameLength)]
         public string UserName { get; set; }
 
-        [Required]
         [EmailAddress]
         [StringLength(AbpUserBase.MaxEmailAddressLength)]
         public string EmailAddress { get; set; }
+
+        [Required]
+        [StringLength(AbpUserBase.MaxPhoneNumberLength)]
+        public string PhoneNumber { get; set; }
 
         [Required]
         [StringLength(AbpUserBase.MaxPlainPasswordLength)]

--- a/src/ArabianCo.Application/MultiTenancy/Dto/CreateTenantDto.cs
+++ b/src/ArabianCo.Application/MultiTenancy/Dto/CreateTenantDto.cs
@@ -17,9 +17,12 @@ namespace ArabianCo.MultiTenancy.Dto
         [StringLength(AbpTenantBase.MaxNameLength)]
         public string Name { get; set; }
 
-        [Required]
         [StringLength(AbpUserBase.MaxEmailAddressLength)]
         public string AdminEmailAddress { get; set; }
+
+        [Required]
+        [StringLength(AbpUserBase.MaxPhoneNumberLength)]
+        public string AdminPhoneNumber { get; set; }
 
         [StringLength(AbpTenantBase.MaxConnectionStringLength)]
         public string ConnectionString { get; set; }

--- a/src/ArabianCo.Application/MultiTenancy/TenantAppService.cs
+++ b/src/ArabianCo.Application/MultiTenancy/TenantAppService.cs
@@ -78,7 +78,7 @@ namespace ArabianCo.MultiTenancy
                 await _roleManager.GrantAllPermissionsAsync(adminRole);
 
                 // Create admin user for the tenant
-                var adminUser = User.CreateTenantAdminUser(tenant.Id, input.AdminEmailAddress);
+                var adminUser = User.CreateTenantAdminUser(tenant.Id, input.AdminEmailAddress, input.AdminPhoneNumber);
                 await _userManager.InitializeOptionsAsync(tenant.Id);
                 CheckErrors(await _userManager.CreateAsync(adminUser, User.DefaultPassword));
                 await CurrentUnitOfWork.SaveChangesAsync(); // To get admin user's id

--- a/src/ArabianCo.Application/Sessions/Dto/UserLoginInfoDto.cs
+++ b/src/ArabianCo.Application/Sessions/Dto/UserLoginInfoDto.cs
@@ -14,5 +14,7 @@ namespace ArabianCo.Sessions.Dto
         public string UserName { get; set; }
 
         public string EmailAddress { get; set; }
+
+        public string PhoneNumber { get; set; }
     }
 }

--- a/src/ArabianCo.Application/Users/Dto/CreateUserDto.cs
+++ b/src/ArabianCo.Application/Users/Dto/CreateUserDto.cs
@@ -22,10 +22,13 @@ namespace ArabianCo.Users.Dto
         [StringLength(AbpUserBase.MaxSurnameLength)]
         public string Surname { get; set; }
 
-        [Required]
         [EmailAddress]
         [StringLength(AbpUserBase.MaxEmailAddressLength)]
         public string EmailAddress { get; set; }
+
+        [Required]
+        [StringLength(AbpUserBase.MaxPhoneNumberLength)]
+        public string PhoneNumber { get; set; }
 
         public bool IsActive { get; set; }
 

--- a/src/ArabianCo.Application/Users/Dto/UserDto.cs
+++ b/src/ArabianCo.Application/Users/Dto/UserDto.cs
@@ -22,10 +22,13 @@ namespace ArabianCo.Users.Dto
         [StringLength(AbpUserBase.MaxSurnameLength)]
         public string Surname { get; set; }
 
-        [Required]
         [EmailAddress]
         [StringLength(AbpUserBase.MaxEmailAddressLength)]
         public string EmailAddress { get; set; }
+
+        [Required]
+        [StringLength(AbpUserBase.MaxPhoneNumberLength)]
+        public string PhoneNumber { get; set; }
 
         public bool IsActive { get; set; }
 

--- a/src/ArabianCo.Application/Users/UserAppService.cs
+++ b/src/ArabianCo.Application/Users/UserAppService.cs
@@ -161,7 +161,7 @@ namespace ArabianCo.Users
         protected override IQueryable<User> CreateFilteredQuery(PagedUserResultRequestDto input)
         {
             return Repository.GetAllIncluding(x => x.Roles)
-                .WhereIf(!input.Keyword.IsNullOrWhiteSpace(), x => x.UserName.Contains(input.Keyword) || x.Name.Contains(input.Keyword) || x.EmailAddress.Contains(input.Keyword))
+                .WhereIf(!input.Keyword.IsNullOrWhiteSpace(), x => x.UserName.Contains(input.Keyword) || x.Name.Contains(input.Keyword) || x.EmailAddress.Contains(input.Keyword) || x.PhoneNumber.Contains(input.Keyword))
                 .WhereIf(input.IsActive.HasValue, x => x.IsActive == input.IsActive);
         }
 

--- a/src/ArabianCo.Core/Authorization/Users/User.cs
+++ b/src/ArabianCo.Core/Authorization/Users/User.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
 using Abp.Authorization.Users;
 using Abp.Extensions;
 
@@ -14,7 +15,7 @@ namespace ArabianCo.Authorization.Users
             return Guid.NewGuid().ToString("N").Truncate(16);
         }
 
-        public static User CreateTenantAdminUser(int tenantId, string emailAddress)
+        public static User CreateTenantAdminUser(int tenantId, string emailAddress, string phoneNumber)
         {
             var user = new User
             {
@@ -23,6 +24,7 @@ namespace ArabianCo.Authorization.Users
                 Name = AdminUserName,
                 Surname = AdminUserName,
                 EmailAddress = emailAddress,
+                PhoneNumber = phoneNumber,
                 Roles = new List<UserRole>()
             };
 
@@ -30,5 +32,13 @@ namespace ArabianCo.Authorization.Users
 
             return user;
         }
+
+        [Required]
+        [StringLength(AbpUserBase.MaxPhoneNumberLength)]
+        public override string PhoneNumber { get; set; }
+
+        [EmailAddress]
+        [StringLength(AbpUserBase.MaxEmailAddressLength)]
+        public override string EmailAddress { get; set; }
     }
 }

--- a/src/ArabianCo.Core/Authorization/Users/UserManager.cs
+++ b/src/ArabianCo.Core/Authorization/Users/UserManager.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.Identity;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Abp.Authorization;
@@ -56,6 +58,17 @@ namespace ArabianCo.Authorization.Users
               settingManager,
               userLoginRepository)
         {
+        }
+
+        public override async Task<User> FindByNameOrEmailAsync(string userNameOrEmailAddress)
+        {
+            var user = await base.FindByNameOrEmailAsync(userNameOrEmailAddress);
+            if (user == null)
+            {
+                user = await Users.FirstOrDefaultAsync(u => u.PhoneNumber == userNameOrEmailAddress);
+            }
+
+            return user;
         }
     }
 }

--- a/src/ArabianCo.Core/Authorization/Users/UserRegistrationManager.cs
+++ b/src/ArabianCo.Core/Authorization/Users/UserRegistrationManager.cs
@@ -37,7 +37,7 @@ namespace ArabianCo.Authorization.Users
             AbpSession = NullAbpSession.Instance;
         }
 
-        public async Task<User> RegisterAsync(string name, string surname, string emailAddress, string userName, string plainPassword, bool isEmailConfirmed)
+        public async Task<User> RegisterAsync(string name, string surname, string emailAddress, string phoneNumber, string userName, string plainPassword, bool isEmailConfirmed)
         {
             CheckForTenant();
 
@@ -49,6 +49,7 @@ namespace ArabianCo.Authorization.Users
                 Name = name,
                 Surname = surname,
                 EmailAddress = emailAddress,
+                PhoneNumber = phoneNumber,
                 IsActive = true,
                 UserName = userName,
                 IsEmailConfirmed = isEmailConfirmed,

--- a/src/ArabianCo.EntityFrameworkCore/EntityFrameworkCore/ArabianCoDbContext.cs
+++ b/src/ArabianCo.EntityFrameworkCore/EntityFrameworkCore/ArabianCoDbContext.cs
@@ -31,9 +31,18 @@ namespace ArabianCo.EntityFrameworkCore
         }
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
+            base.OnModelCreating(modelBuilder);
+
             modelBuilder.Entity<AttributeValue>().HasOne(x => x.Product).WithMany(x => x.AttributeValues).HasForeignKey(x => x.ProductId).OnDelete(DeleteBehavior.Cascade);
             modelBuilder.Entity<Product>().HasMany(x=>x.AttributeValues).WithOne(x=>x.Product).OnDelete(DeleteBehavior.NoAction);
-            base.OnModelCreating(modelBuilder);
+
+            modelBuilder.Entity<User>(b =>
+            {
+                b.Property(u => u.EmailAddress).IsRequired(false);
+                b.Property(u => u.NormalizedEmailAddress).IsRequired(false);
+                b.Property(u => u.PhoneNumber).IsRequired();
+                b.HasIndex(u => new { u.TenantId, u.PhoneNumber });
+            });
         }
         public virtual DbSet<Country> Countries {  get; set; }
         public virtual DbSet<CountryTranslation> CountryTranslations {  get; set; }

--- a/src/ArabianCo.EntityFrameworkCore/EntityFrameworkCore/Seed/Host/HostRoleAndUserCreator.cs
+++ b/src/ArabianCo.EntityFrameworkCore/EntityFrameworkCore/Seed/Host/HostRoleAndUserCreator.cs
@@ -77,6 +77,7 @@ namespace ArabianCo.EntityFrameworkCore.Seed.Host
                     Name = "admin",
                     Surname = "admin",
                     EmailAddress = "admin@aspnetboilerplate.com",
+                    PhoneNumber = "0000000000",
                     IsEmailConfirmed = true,
                     IsActive = true
                 };

--- a/src/ArabianCo.EntityFrameworkCore/EntityFrameworkCore/Seed/Tenants/TenantRoleAndUserBuilder.cs
+++ b/src/ArabianCo.EntityFrameworkCore/EntityFrameworkCore/Seed/Tenants/TenantRoleAndUserBuilder.cs
@@ -72,7 +72,7 @@ namespace ArabianCo.EntityFrameworkCore.Seed.Tenants
             var adminUser = _context.Users.IgnoreQueryFilters().FirstOrDefault(u => u.TenantId == _tenantId && u.UserName == AbpUserBase.AdminUserName);
             if (adminUser == null)
             {
-                adminUser = User.CreateTenantAdminUser(_tenantId, "admin@defaulttenant.com");
+                adminUser = User.CreateTenantAdminUser(_tenantId, "admin@defaulttenant.com", "0000000000");
                 adminUser.Password = new PasswordHasher<User>(new OptionsWrapper<PasswordHasherOptions>(new PasswordHasherOptions())).HashPassword(adminUser, "123qwe");
                 adminUser.IsEmailConfirmed = true;
                 adminUser.IsActive = true;

--- a/src/ArabianCo.EntityFrameworkCore/Migrations/20250901000000_RequiredPhoneNumberAndEmailOptional.cs
+++ b/src/ArabianCo.EntityFrameworkCore/Migrations/20250901000000_RequiredPhoneNumberAndEmailOptional.cs
@@ -1,0 +1,91 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace ArabianCo.Migrations
+{
+    /// <inheritdoc />
+    public partial class RequiredPhoneNumberAndEmailOptional : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "PhoneNumber",
+                table: "AbpUsers",
+                type: "nvarchar(32)",
+                maxLength: 32,
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(32)",
+                oldMaxLength: 32,
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "EmailAddress",
+                table: "AbpUsers",
+                type: "nvarchar(256)",
+                maxLength: 256,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(256)",
+                oldMaxLength: 256);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "NormalizedEmailAddress",
+                table: "AbpUsers",
+                type: "nvarchar(256)",
+                maxLength: 256,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(256)",
+                oldMaxLength: 256);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_AbpUsers_TenantId_PhoneNumber",
+                table: "AbpUsers",
+                columns: new[] { "TenantId", "PhoneNumber" });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_AbpUsers_TenantId_PhoneNumber",
+                table: "AbpUsers");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "NormalizedEmailAddress",
+                table: "AbpUsers",
+                type: "nvarchar(256)",
+                maxLength: 256,
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(256)",
+                oldMaxLength: 256,
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "EmailAddress",
+                table: "AbpUsers",
+                type: "nvarchar(256)",
+                maxLength: 256,
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(256)",
+                oldMaxLength: 256,
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "PhoneNumber",
+                table: "AbpUsers",
+                type: "nvarchar(32)",
+                maxLength: 32,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(32)",
+                oldMaxLength: 32,
+                oldNullable: false);
+        }
+    }
+}

--- a/src/ArabianCo.EntityFrameworkCore/Migrations/ArabianCoDbContextModelSnapshot.cs
+++ b/src/ArabianCo.EntityFrameworkCore/Migrations/ArabianCoDbContextModelSnapshot.cs
@@ -1478,7 +1478,6 @@ namespace ArabianCo.Migrations
                         .HasColumnType("datetime2");
 
                     b.Property<string>("EmailAddress")
-                        .IsRequired()
                         .HasMaxLength(256)
                         .HasColumnType("nvarchar(256)");
 
@@ -1519,7 +1518,6 @@ namespace ArabianCo.Migrations
                         .HasColumnType("nvarchar(64)");
 
                     b.Property<string>("NormalizedEmailAddress")
-                        .IsRequired()
                         .HasMaxLength(256)
                         .HasColumnType("nvarchar(256)");
 
@@ -1538,6 +1536,7 @@ namespace ArabianCo.Migrations
                         .HasColumnType("nvarchar(328)");
 
                     b.Property<string>("PhoneNumber")
+                        .IsRequired()
                         .HasMaxLength(32)
                         .HasColumnType("nvarchar(32)");
 
@@ -1567,6 +1566,7 @@ namespace ArabianCo.Migrations
                     b.HasIndex("LastModifierUserId");
 
                     b.HasIndex("TenantId", "NormalizedEmailAddress");
+                    b.HasIndex("TenantId", "PhoneNumber");
 
                     b.HasIndex("TenantId", "NormalizedUserName");
 

--- a/src/ArabianCo.Web.Core/Authentication/External/ExternalAuthUserInfo.cs
+++ b/src/ArabianCo.Web.Core/Authentication/External/ExternalAuthUserInfo.cs
@@ -10,6 +10,8 @@
 
         public string Surname { get; set; }
 
+        public string PhoneNumber { get; set; }
+
         public string Provider { get; set; }
     }
 }

--- a/src/ArabianCo.Web.Core/Controllers/TokenAuthController.cs
+++ b/src/ArabianCo.Web.Core/Controllers/TokenAuthController.cs
@@ -53,7 +53,7 @@ namespace ArabianCo.Controllers
         public async Task<AuthenticateResultModel> Authenticate([FromBody] AuthenticateModel model)
         {
             var loginResult = await GetLoginResultAsync(
-                model.UserNameOrEmailAddress,
+                model.UserNameOrPhoneNumber,
                 model.Password,
                 GetTenancyNameOrNull()
             );
@@ -142,6 +142,7 @@ namespace ArabianCo.Controllers
                 externalUser.Name,
                 externalUser.Surname,
                 externalUser.EmailAddress,
+                externalUser.PhoneNumber,
                 externalUser.EmailAddress,
                 Authorization.Users.User.CreateRandomPassword(),
                 true
@@ -183,16 +184,16 @@ namespace ArabianCo.Controllers
             return _tenantCache.GetOrNull(AbpSession.TenantId.Value)?.TenancyName;
         }
 
-        private async Task<AbpLoginResult<Tenant, User>> GetLoginResultAsync(string usernameOrEmailAddress, string password, string tenancyName)
+        private async Task<AbpLoginResult<Tenant, User>> GetLoginResultAsync(string usernameOrPhoneNumber, string password, string tenancyName)
         {
-            var loginResult = await _logInManager.LoginAsync(usernameOrEmailAddress, password, tenancyName);
+            var loginResult = await _logInManager.LoginAsync(usernameOrPhoneNumber, password, tenancyName);
 
             switch (loginResult.Result)
             {
                 case AbpLoginResultType.Success:
                     return loginResult;
                 default:
-                    throw _abpLoginResultTypeHelper.CreateExceptionForFailedLoginAttempt(loginResult.Result, usernameOrEmailAddress, tenancyName);
+                    throw _abpLoginResultTypeHelper.CreateExceptionForFailedLoginAttempt(loginResult.Result, usernameOrPhoneNumber, tenancyName);
             }
         }
 

--- a/src/ArabianCo.Web.Core/Models/TokenAuth/AuthenticateModel.cs
+++ b/src/ArabianCo.Web.Core/Models/TokenAuth/AuthenticateModel.cs
@@ -7,8 +7,8 @@ namespace ArabianCo.Models.TokenAuth
     public class AuthenticateModel
     {
         [Required]
-        [StringLength(AbpUserBase.MaxEmailAddressLength)]
-        public string UserNameOrEmailAddress { get; set; }
+        [StringLength(AbpUserBase.MaxUserNameLength)]
+        public string UserNameOrPhoneNumber { get; set; }
 
         [Required]
         [StringLength(AbpUserBase.MaxPlainPasswordLength)]

--- a/src/ArabianCo.Web.Host/wwwroot/swagger/ui/abp.swagger.js
+++ b/src/ArabianCo.Web.Host/wwwroot/swagger/ui/abp.swagger.js
@@ -34,9 +34,9 @@ var abp = abp || {};
     }
 
     function loginUserInternal(tenantId, callback) {
-        var usernameOrEmailAddress = document.getElementById('userName').value;
-        if (!usernameOrEmailAddress) {
-            alert('Username or Email Address is required, please try with a valid value !');
+        var userNameOrPhoneNumber = document.getElementById('userName').value;
+        if (!userNameOrPhoneNumber) {
+            alert('Username or phone number is required, please try with a valid value !');
             return false;
         }
 
@@ -68,7 +68,7 @@ var abp = abp || {};
         addAntiForgeryTokenToXhr(xhr);
         xhr.send(
             JSON.stringify(
-                { usernameOrEmailAddress: usernameOrEmailAddress, password: password }
+                { userNameOrPhoneNumber: userNameOrPhoneNumber, password: password }
             )
         );
     };


### PR DESCRIPTION
## Summary
- Require phone number on users and make email optional
- Allow authentication by phone number or username
- Add EF configuration and migration for phone indexing and nullable email

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-7.0` *(fails: package not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b5704fd238832e9d75dd1412d88d0e