### PR TITLE
Support choosing existing addresses for service requests

### DIFF
--- a/src/ArabianCo.Application/ACInstalls/DTO/CreateACInstallDto.cs
+++ b/src/ArabianCo.Application/ACInstalls/DTO/CreateACInstallDto.cs
@@ -21,13 +21,12 @@ namespace ArabianCo.ACInstalls.DTO
                 public string Note { get; set; }
                 public ACInstallStatus Status { get; set; }
 
-                [Required]
                 public int CityId { get; set; }
-                [Required]
                 public string Street { get; set; }
-                [Required]
                 public string Area { get; set; }
                 public string OtherNotes { get; set; }
+
+                public int? AddressId { get; set; }
 
                 [Required]
                 public int BrandId { get; set; }
@@ -41,6 +40,21 @@ namespace ArabianCo.ACInstalls.DTO
 
                 public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
                 {
+                        if (!AddressId.HasValue)
+                        {
+                                if (CityId <= 0)
+                                {
+                                        yield return new ValidationResult("CityId is required", new[] { nameof(CityId) });
+                                }
+                                if (string.IsNullOrWhiteSpace(Street))
+                                {
+                                        yield return new ValidationResult("Street is required", new[] { nameof(Street) });
+                                }
+                                if (string.IsNullOrWhiteSpace(Area))
+                                {
+                                        yield return new ValidationResult("Area is required", new[] { nameof(Area) });
+                                }
+                        }
                         yield break;
                 }
         }

--- a/src/ArabianCo.Application/MaintenanceRequests/Dto/CreateMaintenanceRequestDto.cs
+++ b/src/ArabianCo.Application/MaintenanceRequests/Dto/CreateMaintenanceRequestDto.cs
@@ -25,13 +25,12 @@ public class CreateMaintenanceRequestDto : IValidatableObject, IShouldInitialize
     [Required]
     public bool IsInWarrantyPeriod { get; set; }
 
-    [Required]
     public int CityId { get; set; }
-    [Required]
     public string Street { get; set; }
-    [Required]
     public string Area { get; set; }
     public string OtherNotes { get; set; }
+
+    public int? AddressId { get; set; }
 
     [Required]
     public int BrandId { get; set; }
@@ -45,6 +44,21 @@ public class CreateMaintenanceRequestDto : IValidatableObject, IShouldInitialize
 
     public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
     {
+        if (!AddressId.HasValue)
+        {
+            if (CityId <= 0)
+            {
+                yield return new ValidationResult("CityId is required", new[] { nameof(CityId) });
+            }
+            if (string.IsNullOrWhiteSpace(Street))
+            {
+                yield return new ValidationResult("Street is required", new[] { nameof(Street) });
+            }
+            if (string.IsNullOrWhiteSpace(Area))
+            {
+                yield return new ValidationResult("Area is required", new[] { nameof(Area) });
+            }
+        }
         yield break;
     }
 }


### PR DESCRIPTION
## Summary
- Allow logged-in users to attach an existing address to maintenance and AC installation requests
- Add optional address selection to request DTOs with validation for anonymous users
- Use retrieved address details when composing notification emails

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b81c2c9404832e92159ace8965a34e