### PR TITLE
Move OurProject text fields to translations

### DIFF
--- a/src/ArabianCo.Application/OurProjects/Dto/CreateOurProjectsDto.cs
+++ b/src/ArabianCo.Application/OurProjects/Dto/CreateOurProjectsDto.cs
@@ -5,10 +5,7 @@ namespace ArabianCo.OurProjects.Dto
 	public class CreateOurProjectsDto
 	{
 		public int AttachmentId { get; set; }
-		public List<OurProjectsTranslationDto> Translations { get; set; }
-		public string Name { get; set; }
-		public string System { get; set; }
-		public int? Ton_of_Refrigeration { get; set; }
-		public string Location { get; set; }
+                public List<OurProjectsTranslationDto> Translations { get; set; }
+                public int? Ton_of_Refrigeration { get; set; }
 	}
 }

--- a/src/ArabianCo.Application/OurProjects/Dto/OurProjectsDto.cs
+++ b/src/ArabianCo.Application/OurProjects/Dto/OurProjectsDto.cs
@@ -6,11 +6,8 @@ namespace ArabianCo.OurProjects.Dto
 {
 	public class OurProjectsDto : EntityDto
 	{
-		public string Name { get; set; }
-		public string System { get; set; }
-		public int? Ton_of_Refrigeration { get; set; }
-		public string Location { get; set; }
-		public LiteAttachmentDto Photo { get; set; }
-		public List<OurProjectsTranslationDto> Translations { get; set; }
+                public int? Ton_of_Refrigeration { get; set; }
+                public LiteAttachmentDto Photo { get; set; }
+                public List<OurProjectsTranslationDto> Translations { get; set; }
 	}
 }

--- a/src/ArabianCo.Application/OurProjects/Dto/OurProjectsTranslationDto.cs
+++ b/src/ArabianCo.Application/OurProjects/Dto/OurProjectsTranslationDto.cs
@@ -11,10 +11,9 @@ namespace ArabianCo.OurProjects.Dto
 		public string Language { get; set; }
 		[Required]
 		public string Name { get; set; }
-		[Required]
-		public string System { get; set; }
-		public int? Ton_of_Refrigeration { get; set; }
-		[Required]
-		public string Location { get; set; }
+                [Required]
+                public string System { get; set; }
+                [Required]
+                public string Location { get; set; }
 	}
 }

--- a/src/ArabianCo.Core/Domain/OurProjects/OurProject.cs
+++ b/src/ArabianCo.Core/Domain/OurProjects/OurProject.cs
@@ -10,11 +10,8 @@ namespace ArabianCo.Domain.OurProjects
 		{
 			Translations = new HashSet<OurProjectsTranslation>();
 		}
-		public ICollection<OurProjectsTranslation> Translations { get; set; }
-		public string Name { get; set; }
-		public string System { get; set; }
-		public int? Ton_of_Refrigeration { get; set; }
-		public string Location { get; set; }
+                public ICollection<OurProjectsTranslation> Translations { get; set; }
+                public int? Ton_of_Refrigeration { get; set; }
 
-	}
+        }
 }

--- a/src/ArabianCo.Core/Domain/OurProjects/OurProjectsTranslation.cs
+++ b/src/ArabianCo.Core/Domain/OurProjects/OurProjectsTranslation.cs
@@ -8,7 +8,9 @@ namespace ArabianCo.Domain.OurProjects
 		public OurProject Core { get; set; }
 		public int CoreId { get; set; }
 		public string Language { get; set; }
-		public string Name { get; set; }
-		public string Description { get; set; }
-	}
+                public string Name { get; set; }
+                public string System { get; set; }
+                public string Location { get; set; }
+                public string Description { get; set; }
+        }
 }

--- a/src/ArabianCo.EntityFrameworkCore/Migrations/20240220120000_MoveOurProjectFieldsToTranslation.cs
+++ b/src/ArabianCo.EntityFrameworkCore/Migrations/20240220120000_MoveOurProjectFieldsToTranslation.cs
@@ -1,0 +1,68 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace ArabianCo.Migrations
+{
+    /// <inheritdoc />
+    public partial class MoveOurProjectFieldsToTranslation : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Location",
+                table: "OurProjects");
+
+            migrationBuilder.DropColumn(
+                name: "Name",
+                table: "OurProjects");
+
+            migrationBuilder.DropColumn(
+                name: "System",
+                table: "OurProjects");
+
+            migrationBuilder.AddColumn<string>(
+                name: "Location",
+                table: "OurProjectsTranslations",
+                type: "nvarchar(max)",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "System",
+                table: "OurProjectsTranslations",
+                type: "nvarchar(max)",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Location",
+                table: "OurProjectsTranslations");
+
+            migrationBuilder.DropColumn(
+                name: "System",
+                table: "OurProjectsTranslations");
+
+            migrationBuilder.AddColumn<string>(
+                name: "Location",
+                table: "OurProjects",
+                type: "nvarchar(max)",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "Name",
+                table: "OurProjects",
+                type: "nvarchar(max)",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "System",
+                table: "OurProjects",
+                type: "nvarchar(max)",
+                nullable: true);
+        }
+    }
+}

--- a/src/ArabianCo.EntityFrameworkCore/Migrations/ArabianCoDbContextModelSnapshot.cs
+++ b/src/ArabianCo.EntityFrameworkCore/Migrations/ArabianCoDbContextModelSnapshot.cs
@@ -2718,15 +2718,6 @@ namespace ArabianCo.Migrations
                     b.Property<long?>("LastModifierUserId")
                         .HasColumnType("bigint");
 
-                    b.Property<string>("Location")
-                        .HasColumnType("nvarchar(max)");
-
-                    b.Property<string>("Name")
-                        .HasColumnType("nvarchar(max)");
-
-                    b.Property<string>("System")
-                        .HasColumnType("nvarchar(max)");
-
                     b.Property<int?>("Ton_of_Refrigeration")
                         .HasColumnType("int");
 
@@ -2758,9 +2749,6 @@ namespace ArabianCo.Migrations
                     b.Property<DateTime?>("DeletionTime")
                         .HasColumnType("datetime2");
 
-                    b.Property<string>("Description")
-                        .HasColumnType("nvarchar(max)");
-
                     b.Property<bool>("IsDeleted")
                         .HasColumnType("bit");
 
@@ -2774,6 +2762,15 @@ namespace ArabianCo.Migrations
                         .HasColumnType("bigint");
 
                     b.Property<string>("Name")
+                        .HasColumnType("nvarchar(max)");
+
+                    b.Property<string>("Description")
+                        .HasColumnType("nvarchar(max)");
+
+                    b.Property<string>("Location")
+                        .HasColumnType("nvarchar(max)");
+
+                    b.Property<string>("System")
                         .HasColumnType("nvarchar(max)");
 
                     b.HasKey("Id");


### PR DESCRIPTION
## Summary
- move the OurProject name, system, and location fields into the translation entity and DTOs
- add a migration and snapshot update to drop the moved columns from OurProjects and add them to translations

## Testing
- not run (dotnet CLI is unavailable in the execution environment)

------
https://chatgpt.com/codex/tasks/task_e_68d90660af0c832e95f137765a392d53